### PR TITLE
Support Next.js image component in typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bu/
 *.psd
 logo-tmplt.psd
 playground.js
+playground.ts

--- a/snippets/snippets-ts.json
+++ b/snippets/snippets-ts.json
@@ -320,5 +320,20 @@
     "prefix": "imusrtr",
     "body": "import { useRouter } from 'next/router';",
     "description": "Next.js { useRouter } import"
+  },
+  "Import Next Image component": {
+    "prefix": "imimg",
+    "body": "import Image from 'next/image';",
+    "description": "Next.js 10 Image component import"
+  },
+  "Use sized Next Image component": {
+    "prefix": "nimg",
+    "body": "<Image alt=\"$1\" src=\"$1\" width=\"$1\" height=\"$1\" />",
+    "description": "Use sized Next Image component"
+  },
+  "Use unsized Next Image component": {
+    "prefix": "nuimg",
+    "body": "<Image alt=\"$1\" src=\"$1\" unsized=\"$1\" />",
+    "description": "Use sized Next Image component"
   }
 }


### PR DESCRIPTION
Implements #10 

Nothing special about the component. From what I can see it has a general JSX.Element type, so no new typescript type imports needed either.

I did notice that the `nuimg` snippet defaults to a deprecated property `unsized`. Wanted to point that out in case you weren't aware.